### PR TITLE
fix table quoting unescaping

### DIFF
--- a/lib/acts_as_archive.rb
+++ b/lib/acts_as_archive.rb
@@ -208,7 +208,7 @@ class ActsAsArchive
         @mutex.synchronize do
           unless ActsAsArchive.disabled
             from, where = /DELETE FROM (.+)/i.match(sql)[1].split(/\s+WHERE\s+/i, 2)
-            from = from.strip.gsub(/`/, '').split(/\s*,\s*/)
+            from = from.strip.gsub(/[`"]/, '').split(/\s*,\s*/)
         
             ActsAsArchive.find(from).each do |config|
               ActsAsArchive.move(config, where)


### PR DESCRIPTION
hello, 
I'm using rails 3.0.3 with pg. It looks like it escapes table names with " character, so without this it's failing (not finding any config because of calling find('"name"') instead of ('name') and therefore not making any archive - quite painful, because of no errors). Hope this helps

regards,
comboy
