### PR TITLE
update to README as well as update to archive class creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,70 +3,74 @@ ActsAsArchive
 
 Don't delete your records, move them to a different table.
 
-Like <code>acts\_as\_paranoid</code>, but doesn't mess with your SQL queries.
+Like `acts_as_paranoid`, but doesn't mess with your SQL queries.
 
 Install
 -------
 
-<pre>
-gem install acts_as_archive
-</pre>
+    gem install acts_as_archive
 
 ### Rails 2
 
 #### config/environment.rb
 
-<pre>
-config.gem 'acts_as_archive'
-</pre>
+    config.gem 'acts_as_archive'
+
+#### config/initializers/load_acts_as_archive.rb
+
+    ActsAsArchive.load_from_yaml(Rails.root)
 
 ### Rails 3
 
 #### Gemfile
 
-<pre>
-gem 'acts_as_archive'
-</pre>
+    gem 'acts_as_archive'
 
 ### Sinatra
 
-<pre>
-require 'acts_as_archive'
+    require 'acts_as_archive'
+    
+    class Application < Sinatra::Base
+      include ActsAsArchive::Adapters::Sinatra
+    end
 
-class Application &lt; Sinatra::Base
-  include ActsAsArchive::Adapters::Sinatra
-end
-</pre>
-
-config/acts\_as\_archive.yml
+config/acts_as_archive.yml
 ----------------------------
 
-Create <code>config/acts\_as\_archive.yml</code> to define the archive class and archive table for each of your models:
+Create `config/acts_as_archive.yml` to define the archive class and archive table for each of your models:
 
-<pre>
-Article:
-  - class: Article::Archive
-    table: archived_articles
-</pre>
-
-It is expected that neither the archive class or archive table exist yet. <code>ActsAsArchive</code> will create these automatically.
+    Article:
+      - class: Article::Archive
+        table: archived_articles
+    
+It is expected that neither the archive class or archive table exist yet. `ActsAsArchive` will create these automatically.
 
 Migrate
 -------
 
-Run <code>rake db:migrate</code>. Your archive table is created automatically.
+    class CreateArchiveTables < ActiveRecord::Migration
+      def self.up
+        ActsAsArchive.load_from_yaml(Rails.root)
+        ActsAsArchive.migrate
+      end
+    
+      def self.down
+      end
+    end
+
+Run `rake db:migrate`. 
 
 That's it!
 ----------
 
-Use <code>destroy</code>, <code>destroy\_all</code>, <code>delete</code>, and <code>delete_all</code> like you normally would.
+Use `destroy`, `destroy_all`, `delete`, and `delete_all` like you normally would.
 
 Records move into the archive table instead of being destroyed.
 
 Automatically archive relationships
 -----------------------------------
 
-If your model's relationship has the <code>:dependent</code> option, and the relationship also uses <code>acts\_as\_archive</code>, that relationship will archive automatically.
+If your model's relationship has the `:dependent` option, and the relationship also uses `acts_as_archive`, that relationship will archive automatically.
 
 What if my schema changes?
 --------------------------
@@ -80,49 +84,41 @@ Query the archive
 
 Use the archive class you specified in the configuration:
 
-<pre>
-Article::Archive.first
-</pre>
+    Article::Archive.first
 
 Delete records without archiving
 --------------------------------
 
 Use any of the destroy methods, but add a bang (!):
 
-<pre>
-Article::Archive.first.destroy!
-Article.delete_all!([ "id in (?)", [ 1, 2, 3 ] ])
-</pre>
+    Article::Archive.first.destroy!
+    Article.delete_all!([ "id in (?)", [ 1, 2, 3 ] ])
 
 Restore from the archive
 ------------------------
 
 Use any of the destroy/delete methods on the archived record to move it back to its original table:
 
-<pre>
-Article::Archive.first.destroy
-Article::Archive.delete_all([ "id in (?)", [ 1, 2, 3 ] ])
-</pre>
+    Article::Archive.first.destroy
+    Article::Archive.delete_all([ "id in (?)", [ 1, 2, 3 ] ])
 
 Any relationships that were automatically archived will be restored as well.
 
 Magic columns
 -------------
 
-You will find an extra <code>deleted_at</code> datetime column on the archive table.
+You will find an extra `deleted_at` datetime column on the archive table.
 
-You may manually add a <code>restored_at</code> datetime column to the origin table if you wish to store restoration time as well.
+You may manually add a `restored_at` datetime column to the origin table if you wish to store restoration time as well.
 
-Migrate from acts\_as\_paranoid
+Migrate from `acts_as_paranoid`
 -------------------------------
 
-Add this line to a migration, or run it via <code>script/console</code>:
+Add this line to a migration, or run it via `script/console`:
 
-<pre>
-Article.migrate_from_acts_as_paranoid
-</pre>
+    Article.migrate_from_acts_as_paranoid
 
-This copies all records with non-null <code>deleted_at</code> values to the archive.
+This copies all records with non-null `deleted_at` values to the archive.
 
 Running specs
 -------------

--- a/lib/acts_as_archive.rb
+++ b/lib/acts_as_archive.rb
@@ -60,6 +60,10 @@ class ActsAsArchive
       end
     end
     
+    def migrate
+      AlsoMigrate::Migrator.migrate
+    end
+    
     def move(config, where, merge_options={})
       options = config[:options].dup.merge(merge_options)
       if options[:conditions]
@@ -225,5 +229,5 @@ end
 ::ActiveRecord::Base.send(:include, ::ActsAsArchive::Base)
 ::ActiveRecord::ConnectionAdapters::DatabaseStatements.send(:include, ::ActsAsArchive::DatabaseStatements)
 
-require "acts_as_archive/adapters/rails#{Rails.version[0..0]}" if defined?(Rails)
+require "acts_as_archive/adapters/rails3" if defined?(Rails) && Rails.version[0..0] == "3"
 require "acts_as_archive/adapters/sinatra" if defined?(Sinatra)

--- a/lib/acts_as_archive/adapters/rails2.rb
+++ b/lib/acts_as_archive/adapters/rails2.rb
@@ -1,1 +1,1 @@
-ActsAsArchive.load_from_yaml(Rails.root)
+# ActsAsArchive.load_from_yaml(Rails.root)

--- a/lib/acts_as_archive/adapters/rails2.rb
+++ b/lib/acts_as_archive/adapters/rails2.rb
@@ -1,1 +1,0 @@
-# ActsAsArchive.load_from_yaml(Rails.root)


### PR DESCRIPTION
Hey guys,
I recently sent a pull request for also_migrate that entailed explicitly running the migrations. These change sets piggy back off of that. I added the ability to proxy the explicit migration call through acts_as_archive. I also updated the dynamic Archive class creation so that the archive will inherit from self (just in case there are any methods that are needed from the parent class). I pretty much ripped elmatou's fix for the polymorphic associations because I needed it. I removed the automatic yaml loading for rails 2 because certain classes were dependent upon other gems being loaded before they could be loaded. Instead, load the yaml as an initializer. I documented that as part of the README. I didn't update the rails 3 or sinatra adapter because I'm not sure if this is an issue there. 
