### PR TITLE
YML issue with Rubygems version

### DIFF
--- a/config/gemsets.yml
+++ b/config/gemsets.yml
@@ -1,10 +1,10 @@
 acts_as_archive:
-  rake: >=0.8.7
-  rspec: ~>1.0
+  rake: ">=0.8.7"
+  rspec: "~>1.0"
   default:
-    active_wrapper-solo: =0.4.4
-    also_migrate: =0.3.5
-    externals: =1.0.2
-    framework_fixture: =0.1.3
-    mover: =0.3.6
-    rack-test: =0.5.6
+    active_wrapper-solo: "=0.4.4"
+    also_migrate: "=0.3.5"
+    externals: "=1.0.2"
+    framework_fixture: "=0.1.3"
+    mover: "=0.3.6"
+    rack-test: "=0.5.6"


### PR DESCRIPTION
Ensured that all the mentioned versions were surrounded with quotes as there was some issue with Rubygems 1.8.6 with the use of this gem.
