### PR TITLE
fix timestamps missing on rails generated migrations

### DIFF
--- a/config/gemsets.yml
+++ b/config/gemsets.yml
@@ -3,7 +3,7 @@ acts_as_archive:
   rspec: "~>1.0"
   default:
     active_wrapper-solo: "=0.4.4"
-    also_migrate: "=0.3.5"
+    also_migrate: ">=0.3.6"
     externals: "=1.0.2"
     framework_fixture: "=0.1.3"
     mover: "=0.3.6"


### PR DESCRIPTION
The timestamps are missing on the migrations generated after adding acts_as_archive to my project.  It appears to be related to a bug in also_migrate.  This just updates the version of also_migrate that acts_as_archive depends on.
